### PR TITLE
JBIDE-13329 SDK-less Targets

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,9 +95,9 @@
 		<tpc.targetKind>unified</tpc.targetKind>
 
 		<!-- In case no profile fits your requested TP version, directly override this property -->
-		<TARGET_PLATFORM_VERSION>4.2.0.c-SNAPSHOT</TARGET_PLATFORM_VERSION>
+		<TARGET_PLATFORM_VERSION>4.2.0.d-SNAPSHOT</TARGET_PLATFORM_VERSION>
 		<!-- default value for the "maximum" profiles -->
-		<TARGET_PLATFORM_VERSION-maximum>4.2.1.a-SNAPSHOT</TARGET_PLATFORM_VERSION-maximum>
+		<TARGET_PLATFORM_VERSION-maximum>4.2.1.b-SNAPSHOT</TARGET_PLATFORM_VERSION-maximum>
 
 	</properties>
 

--- a/target-platforms/jbdevstudio-4.2.0.d/multiple/multiple.target
+++ b/target-platforms/jbdevstudio-4.2.0.d/multiple/multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbosstools-4.2.0.c">
+<target includeMode="feature" name="jbdevstudio-4.2.0.c">
 	<!-- Pro tip: to convert
 			from org.eclipse.foo_4.6.0.v201005032111-777K4AkF7B77R7c7N77.jar
 		to <unit version="4.6.0.v201005032111-777K4AkF7B77R7c7N77" id="org.eclipse.foo.feature.group"/>
@@ -75,8 +75,9 @@
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse/20120926-1337/"/>
 
 			<!-- m2e, m2e-wtp, m2e-apt, m2e-jdt, m2e-wro4j, m2e-buildhelper + deps -->
-			<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.feature.feature.group" version="1.2.0.20120903-1050"/>
+			<!-- Maven tests require a bundle from m2e SDK -->
+			<unit id="org.eclipse.m2e.tests.common" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.wtp.feature.feature.group" version="0.16.0.20120914-0945"/>
 			<unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.15.0.201207090125-signed-201209140800"/>
 			<unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.0.1.201209200721"/>
@@ -136,21 +137,12 @@
 			<!-- <unit id="org.eclipse.platform.feature.group" version="3.8.0.v20120607-071945-9gF7jI7nG5qByXMVdkhRMWBQlF4PnDCLybDCPQ"/> -->
 			<unit id="org.eclipse.platform.feature.group" version="4.2.0.v20120608-135145-9JF7BHV8FyMteji0Oi_ePMz0xuZ8TVo7lV0z0ecb"/>
 			<unit id="org.eclipse.platform.ide" version="4.2.0.I20120608-1400"/>
-			<unit id="org.eclipse.platform.sdk" version="4.2.0.I20120608-1400"/>
-			<unit id="org.eclipse.sdk.feature.group" version="4.2.0.v20120528-1648-7T7oDFDPz-3FepgRqG6kkFFY0UF4_otgmt0XcoU3Zh27X"/>
-			<unit id="org.eclipse.sdk.ide" version="4.2.0.I20120608-1400"/>
 			<unit id="org.eclipse.cvs.feature.group" version="1.3.200.v20120525-1249-7B79FJJAkF7BF7SDL5EAJT"/>
 			<unit id="org.eclipse.jdt.feature.group" version="3.8.0.v20120525-1249-8-8nFqlFNOfwKDRGz-pXLdGxEM83"/>
 			<unit id="org.eclipse.equinox.server.core.feature.group" version="1.2.0.v20120522-1841-7K7VFMRF7RZHQYI0Yh8U-ov"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="3.6.0.v20120522-1813-7P7OG2BFLWUl7UmbVUO9iCm"/>
-			<unit id="org.eclipse.equinox.compendium.sdk.feature.group" version="3.8.0.v20120522-1841-7X7eGb7FPGjtJjv1kjS_NdG"/>
-			<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.8.0.v20120522-1813-85FAcGbBFoYTldHrOJw3cF4q"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.100.v20120524-0542-4-Bh9oB58A5N9L28PCQ"/>
 			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.0.v20120524-0542-62DG9JXTlSiz-UbcP0w0KGe8CBOP"/>
-			<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.8.0.v20120524-0542-9N89H_mGMMn84Osz0TAoT279BRQD"/>
-			<unit id="org.eclipse.equinox.serverside.sdk.feature.group" version="3.8.0.v20120522-1841-9Q7dFszFYGis9uYGz0QodZP3fH0t"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="3.8.0.v20120522-1841-7M7fA78g5_y-eMftHxcd13UXuq5J"/>
-			<unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.0.200.v20120522-1841-79-FKsEVVFNVFsVk7O6G6"/>
 			<unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.1.0.v20120522-1841-8077C0F8NcJTbL1ab47MJ5"/>
 			<unit id="org.eclipse.equinox.server.p2.feature.group" version="1.2.0.v20120522-1841-7z7_FfoFTy21Yu4Ydp_WohB38"/>
 			<unit id="org.eclipse.equinox.server.servletbridge.feature.group" version="1.0.101.v20120522-1841-42F9w9oB58B5KBB2ADHO"/>
@@ -249,7 +241,6 @@
 			<unit id="org.eclipse.mylyn.cvs.feature.group" version="1.0.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.git.feature.group" version="1.0.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.versions.feature.group" version="1.0.0.v20120612-0600"/>
-			<unit id="org.eclipse.mylyn.commons.sdk.feature.group" version="3.8.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.tasks.ui" version="3.8.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.tasks.core" version="3.8.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.tasks.bugs" version="3.8.0.v20120612-0600"/>
@@ -333,7 +324,6 @@
 			<unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.2.0.v201203150000-56A7AkF7BF7NAP7777"/>
 
 			<unit id="org.eclipse.jsf.feature.feature.group" version="3.4.0.v201111022140-7E7JFBZF9JgLWZLz0U0QoZm3357"/>
-			<unit id="org.eclipse.jsf.feature.source.feature.group" version="3.4.0.v201111022140-7E7JFBZF9JgLWZLz0U0QoZm3357"/>			
 			<unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.4.0.v201108231500-377DG8s73543J5H6D66"/>
 			<unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.4.0.v201108110300-52FShAkF7BA8O8J9OC8"/>
 			<unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.4.0.v201107072300-7b7JIM0FSK2WM1PS9Ar7AKUz0TrWn"/>
@@ -379,6 +369,7 @@
 		</location>
 
 		<!-- Only in JBT: SWTBot -->
+		<!--
 		<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/swtbot/2.0.5/"/>
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.0.5.20111003_1754-3676ac8-dev-e36"/>
@@ -387,23 +378,27 @@
 			<unit id="org.eclipse.swtbot.eclipse.test.junit4.feature.group" version="2.0.5.20111003_1754-3676ac8-dev-e36"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="2.0.5.20111003_1754-3676ac8-dev-e36"/>
 		</location>
+		-->
 
 		<!-- Only in JBT: BIRT -->
+		<!--
 		<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/birt/4.2.0.v20120613/"/>
-			<unit id="org.eclipse.birt.osgi.runtime.sdk.feature.group" version="4.2.0.v20120611-793-87iDWCFP8ZDTAN72TPI4jrXA"/>
 			<unit id="org.eclipse.birt.feature.group" version="4.2.0.v20120611-C_BC7CGWoJMfAnw8Y8QVz0nD0JPl"/>
 			<unit id="org.eclipse.birt.integration.wtp.feature.group" version="4.2.0.v20120613-1143-51-7w3123172402254"/>
 			<unit id="org.eclipse.birt.chart.feature.group" version="4.2.0.v20120611-828i2FQCnvK_6W8GmbB8"/>
 			<unit id="org.eclipse.birt.chart.integration.wtp.feature.group" version="4.2.0.v20120613-1143-51-7w3123172402254"/>
 		</location>
+		-->
 
 		<!-- Only in JBT: GWT/GPE -->
+		<!--
 		<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/gwt/3.1.0.v201208080121-rel-r42"/>
 			<unit id="com.google.gdt.eclipse.suite.e42.feature.feature.group" version="3.1.0.v201208080121-rel-r42"/>
 			<unit id="com.google.gwt.eclipse.sdkbundle.e42.feature.feature.group" version="2.4.0.v201208080121-rel-r42"/>
 		</location>
+		-->
 
 	</locations>
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>

--- a/target-platforms/jbdevstudio-4.2.0.d/multiple/pom.xml
+++ b/target-platforms/jbdevstudio-4.2.0.d/multiple/pom.xml
@@ -2,14 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-		<parent>
+	<parent>
 		<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.1.a-SNAPSHOT</version>
+		<version>4.2.0.d-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 	<artifactId>multiple</artifactId>
-	<name>jbdevstudio Multiple (Composite) Target Platform 4.2.1.a</name>
+	<name>jbdevstudio Multiple (Composite) Target Platform 4.2.0.d</name>
 	<packaging>pom</packaging>
 
 	<build>
@@ -59,7 +59,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<profiles>
 		<profile>
 			<id>multiple2repo</id>
@@ -86,5 +86,5 @@
 			</build>
 		</profile>
 	</profiles>
-
+	
 </project>

--- a/target-platforms/jbdevstudio-4.2.0.d/pom.xml
+++ b/target-platforms/jbdevstudio-4.2.0.d/pom.xml
@@ -7,9 +7,9 @@
 		<artifactId>target-platforms</artifactId>
 		<version>4.1.0.Alpha1-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
+	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 	<artifactId>all</artifactId>
-	<version>4.2.1.a-SNAPSHOT</version>
+	<version>4.2.0.d-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>multiple</module>

--- a/target-platforms/jbdevstudio-4.2.0.d/unified/pom.xml
+++ b/target-platforms/jbdevstudio-4.2.0.d/unified/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.0.c-SNAPSHOT</version>
+		<version>4.2.0.d-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 	<artifactId>unified</artifactId>
-	<name>jbdevstudio Unified (Aggregate) Target Platform 4.2.0.c</name>
+	<name>jbdevstudio Unified (Aggregate) Target Platform 4.2.0.d</name>
 	<packaging>pom</packaging>
 
 	<build>

--- a/target-platforms/jbdevstudio-4.2.1.b/multiple/multiple.target
+++ b/target-platforms/jbdevstudio-4.2.1.b/multiple/multiple.target
@@ -75,8 +75,9 @@
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse/20120926-1337/"/>
 
 			<!-- m2e, m2e-wtp, m2e-apt, m2e-jdt, m2e-wro4j, m2e-buildhelper + deps -->
-			<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.feature.feature.group" version="1.2.0.20120903-1050"/>
+			<!-- Maven tests require a bundle from m2e SDK -->
+			<unit id="org.eclipse.m2e.tests.common" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.wtp.feature.feature.group" version="0.16.0.20120914-0945"/>
 			<unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.15.0.201207090125-signed-201209140800"/>
 			<unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.0.1.201209200721"/>
@@ -136,21 +137,12 @@
 			<!-- <unit id="org.eclipse.platform.feature.group" version="3.8.0.v20120607-071945-9gF7jI7nG5qByXMVdkhRMWBQlF4PnDCLybDCPQ"/> -->
 			<unit id="org.eclipse.platform.feature.group" version="4.2.1.v20120814-120134-9JF7BHVGFyMveli1uX6aTH0q-eAap6PAgOP5mO"/>
 			<unit id="org.eclipse.platform.ide" version="4.2.1.M20120914-1800"/>
-			<unit id="org.eclipse.platform.sdk" version="4.2.1.M20120914-1800"/>
-			<unit id="org.eclipse.sdk.feature.group" version="4.2.1.v20120814-120134-7T7oDODQ-3Heq-afCDlg7T4xJuvxaC2ohMfCfB5451Rz0"/>
-			<unit id="org.eclipse.sdk.ide" version="4.2.1.M20120914-1800"/>
 			<unit id="org.eclipse.cvs.feature.group" version="1.3.200.v20120525-1249-7B79FJJAkF7BF7VEH5IAJT"/>
 			<unit id="org.eclipse.jdt.feature.group" version="3.8.1.v20120814-104540-8-8nFqpFNOfwKDRVz-tXOcL5d_83"/>
 			<unit id="org.eclipse.equinox.server.core.feature.group" version="1.2.0.v20120522-1841-7K7VFO1F7RZHQZI4_c8StnvFB"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="3.6.0.v20120522-1813-7P7OG2BFLWUl7UmbVUO9iCm"/>
-			<unit id="org.eclipse.equinox.compendium.sdk.feature.group" version="3.8.0.v20120522-1841-7X7eGb7FPGjtJjv1kjS_NdG"/>
-			<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.8.0.v20120522-1813-85FAcGbFFoYTldJrUNk3a52oHJ"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.100.v20120524-0542-4-Bh9oB58A5N9L28PCQ"/>
 			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.0.v20120524-0542-62DG9JXTlSiz-UbcP0w0KGl9CKNP"/>
-			<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.8.0.v20120524-0542-9N89H_oGMMn84Qsz0iIohu4jLeQD"/>
-			<unit id="org.eclipse.equinox.serverside.sdk.feature.group" version="3.8.0.v20120522-1841-9Q7dFszFYGis9uZsz0QodZP4fL9p"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="3.8.0.v20120522-1841-7M7fA78g5_y-g-jtHxcd5k8q8lFR"/>
-			<unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.0.200.v20120522-1841-79-FKsEVVFNVFsVk7O6G6"/>
 			<unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.1.0.v20120522-1841-8077C0F8NcJTbL1ab47MJ5"/>
 			<unit id="org.eclipse.equinox.server.p2.feature.group" version="1.2.0.v20120522-1841-7z7_FfoFTy21Yu4Ykq_engx38"/>
 			<unit id="org.eclipse.equinox.server.servletbridge.feature.group" version="1.0.101.v20120522-1841-42F9w9oB58B5KBB2ADHO"/>
@@ -249,7 +241,6 @@
 			<unit id="org.eclipse.mylyn.cvs.feature.group" version="1.0.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.git.feature.group" version="1.0.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.versions.feature.group" version="1.0.2.v20120916-1200"/>
-			<unit id="org.eclipse.mylyn.commons.sdk.feature.group" version="3.8.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.tasks.ui" version="3.8.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.tasks.core" version="3.8.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.tasks.bugs" version="3.8.2.v20120916-1200"/>
@@ -333,7 +324,6 @@
 			<unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.2.1.v201208222210-56ABAkF7BF7cFFFFB7"/>
 
 			<unit id="org.eclipse.jsf.feature.feature.group" version="3.4.1.v201208241503-7E7JFBjF9JgLWgMhh4X6Ps"/>
-			<unit id="org.eclipse.jsf.feature.source.feature.group" version="3.4.1.v201208241503-7E7JFBjF9JgLWgMhh4X6Ps"/>
 			<unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.4.0.v201108231500-377DG8s73543J5H6D66"/>
 			<unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.4.0.v201108110300-52FShAkF7BA8O8J9OC8"/>
 			<unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.4.0.v201107072300-7b7JIM0FSK2WM1PS9Ar7AKUz0TrWn"/>
@@ -391,7 +381,6 @@
 		<!-- Only in JBT: BIRT -->
 		<!-- <location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/birt/4.2.1.v20120912/"/>
-			<unit id="org.eclipse.birt.osgi.runtime.sdk.feature.group" version="4.2.1.v20120820-793187qD_D0RBQLXOVH-wQkmJ1cI"/>
 			<unit id="org.eclipse.birt.feature.group" version="4.2.1.v20120820-ChBG8UGYgRQlJ7y9Lz-wS7nDcRL4"/>
 			<unit id="org.eclipse.birt.integration.wtp.feature.group" version="4.2.1.v20120912-1721-5107w31231A2302832"/>
 			<unit id="org.eclipse.birt.chart.feature.group" version="4.2.1.v20120820-828i7EFQCnvK_6wFGvqLR"/>

--- a/target-platforms/jbdevstudio-4.2.1.b/multiple/pom.xml
+++ b/target-platforms/jbdevstudio-4.2.1.b/multiple/pom.xml
@@ -2,40 +2,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
+		<parent>
+		<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.1.a-SNAPSHOT</version>
+		<version>4.2.1.b-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
-	<artifactId>unified</artifactId>
-	<name>jbosstools Unified (Aggregate) Target Platform 4.2.1.a</name>
+	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
+	<artifactId>multiple</artifactId>
+	<name>jbdevstudio Multiple (Composite) Target Platform 4.2.1.b</name>
 	<packaging>pom</packaging>
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.jboss.tools.tycho-plugins</groupId>
-				<artifactId>target-platform-utils</artifactId>
-				<version>0.0.1-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<id>create-target</id>
-						<phase>generate-resources</phase>
-						<goals>
-							<goal>flatten-target</goal>
-						</goals>
-						<configuration>
-							<sourceTargetArtifact>
-								<groupId>${project.groupId}</groupId>
-								<artifactId>multiple</artifactId>
-								<version>${project.version}</version>
-							</sourceTargetArtifact>
-							<targetRepositoryUrl>http://download.jboss.org/jbosstools/updates/juno/SR1a/REPO/</targetRepositoryUrl>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>target-platform-validation-plugin</artifactId>
@@ -48,7 +26,7 @@
 						</goals>
 						<configuration>
 							<targetFiles>
-								<param>${project.build.directory}/${project.artifactId}.target</param>
+								<param>multiple.target</param>
 							</targetFiles>
 							<failOnError>true</failOnError>
 						</configuration>
@@ -68,10 +46,11 @@
 						</goals>
 						<configuration>
 							<artifacts>
+								<!-- add more artifacts if want more target platforms -->
 								<artifact>
-									<file>${project.build.directory}/${project.artifactId}.target</file>
+									<file>multiple.target</file>
 									<type>target</type>
-									<classifier>${project.artifactId}</classifier>
+									<classifier>multiple</classifier>
 								</artifact>
 							</artifacts>
 						</configuration>
@@ -80,4 +59,32 @@
 			</plugin>
 		</plugins>
 	</build>
+	
+	<profiles>
+		<profile>
+			<id>multiple2repo</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<!-- Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=389052  -->
+						<groupId>org.jboss.tools.tycho-plugins</groupId>
+						<artifactId>target-platform-utils</artifactId>
+						<version>0.0.1-SNAPSHOT</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>mirror-target-to-repo</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/target-platforms/jbdevstudio-4.2.1.b/pom.xml
+++ b/target-platforms/jbdevstudio-4.2.1.b/pom.xml
@@ -7,9 +7,9 @@
 		<artifactId>target-platforms</artifactId>
 		<version>4.1.0.Alpha1-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
+	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 	<artifactId>all</artifactId>
-	<version>4.2.0.c-SNAPSHOT</version>
+	<version>4.2.1.b-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>multiple</module>

--- a/target-platforms/jbdevstudio-4.2.1.b/unified/pom.xml
+++ b/target-platforms/jbdevstudio-4.2.1.b/unified/pom.xml
@@ -5,11 +5,11 @@
 		<parent>
 		<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.1.a-SNAPSHOT</version>
+		<version>4.2.1.b-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
 	<artifactId>unified</artifactId>
-	<name>jbdevstudio Unified (Aggregate) Target Platform 4.2.1.a</name>
+	<name>jbdevstudio Unified (Aggregate) Target Platform 4.2.1.b</name>
 	<packaging>pom</packaging>
 
 	<build>

--- a/target-platforms/jbosstools-4.2.0.d/multiple/multiple.target
+++ b/target-platforms/jbosstools-4.2.0.d/multiple/multiple.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><?pde version="3.6"?>
-<target includeMode="feature" name="jbdevstudio-4.2.0.c">
+<target includeMode="feature" name="jbosstools-4.2.0.c">
 	<!-- Pro tip: to convert
 			from org.eclipse.foo_4.6.0.v201005032111-777K4AkF7B77R7c7N77.jar
 		to <unit version="4.6.0.v201005032111-777K4AkF7B77R7c7N77" id="org.eclipse.foo.feature.group"/>
@@ -75,8 +75,9 @@
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse/20120926-1337/"/>
 
 			<!-- m2e, m2e-wtp, m2e-apt, m2e-jdt, m2e-wro4j, m2e-buildhelper + deps -->
-			<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.feature.feature.group" version="1.2.0.20120903-1050"/>
+			<!-- Maven tests require a bundle from m2e SDK -->
+			<unit id="org.eclipse.m2e.tests.common" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.wtp.feature.feature.group" version="0.16.0.20120914-0945"/>
 			<unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.15.0.201207090125-signed-201209140800"/>
 			<unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.0.1.201209200721"/>
@@ -136,21 +137,12 @@
 			<!-- <unit id="org.eclipse.platform.feature.group" version="3.8.0.v20120607-071945-9gF7jI7nG5qByXMVdkhRMWBQlF4PnDCLybDCPQ"/> -->
 			<unit id="org.eclipse.platform.feature.group" version="4.2.0.v20120608-135145-9JF7BHV8FyMteji0Oi_ePMz0xuZ8TVo7lV0z0ecb"/>
 			<unit id="org.eclipse.platform.ide" version="4.2.0.I20120608-1400"/>
-			<unit id="org.eclipse.platform.sdk" version="4.2.0.I20120608-1400"/>
-			<unit id="org.eclipse.sdk.feature.group" version="4.2.0.v20120528-1648-7T7oDFDPz-3FepgRqG6kkFFY0UF4_otgmt0XcoU3Zh27X"/>
-			<unit id="org.eclipse.sdk.ide" version="4.2.0.I20120608-1400"/>
 			<unit id="org.eclipse.cvs.feature.group" version="1.3.200.v20120525-1249-7B79FJJAkF7BF7SDL5EAJT"/>
 			<unit id="org.eclipse.jdt.feature.group" version="3.8.0.v20120525-1249-8-8nFqlFNOfwKDRGz-pXLdGxEM83"/>
 			<unit id="org.eclipse.equinox.server.core.feature.group" version="1.2.0.v20120522-1841-7K7VFMRF7RZHQYI0Yh8U-ov"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="3.6.0.v20120522-1813-7P7OG2BFLWUl7UmbVUO9iCm"/>
-			<unit id="org.eclipse.equinox.compendium.sdk.feature.group" version="3.8.0.v20120522-1841-7X7eGb7FPGjtJjv1kjS_NdG"/>
-			<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.8.0.v20120522-1813-85FAcGbBFoYTldHrOJw3cF4q"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.100.v20120524-0542-4-Bh9oB58A5N9L28PCQ"/>
 			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.0.v20120524-0542-62DG9JXTlSiz-UbcP0w0KGe8CBOP"/>
-			<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.8.0.v20120524-0542-9N89H_mGMMn84Osz0TAoT279BRQD"/>
-			<unit id="org.eclipse.equinox.serverside.sdk.feature.group" version="3.8.0.v20120522-1841-9Q7dFszFYGis9uYGz0QodZP3fH0t"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="3.8.0.v20120522-1841-7M7fA78g5_y-eMftHxcd13UXuq5J"/>
-			<unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.0.200.v20120522-1841-79-FKsEVVFNVFsVk7O6G6"/>
 			<unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.1.0.v20120522-1841-8077C0F8NcJTbL1ab47MJ5"/>
 			<unit id="org.eclipse.equinox.server.p2.feature.group" version="1.2.0.v20120522-1841-7z7_FfoFTy21Yu4Ydp_WohB38"/>
 			<unit id="org.eclipse.equinox.server.servletbridge.feature.group" version="1.0.101.v20120522-1841-42F9w9oB58B5KBB2ADHO"/>
@@ -249,7 +241,6 @@
 			<unit id="org.eclipse.mylyn.cvs.feature.group" version="1.0.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.git.feature.group" version="1.0.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.versions.feature.group" version="1.0.0.v20120612-0600"/>
-			<unit id="org.eclipse.mylyn.commons.sdk.feature.group" version="3.8.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.tasks.ui" version="3.8.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.tasks.core" version="3.8.0.v20120612-0600"/>
 			<unit id="org.eclipse.mylyn.tasks.bugs" version="3.8.0.v20120612-0600"/>
@@ -333,7 +324,6 @@
 			<unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.2.0.v201203150000-56A7AkF7BF7NAP7777"/>
 
 			<unit id="org.eclipse.jsf.feature.feature.group" version="3.4.0.v201111022140-7E7JFBZF9JgLWZLz0U0QoZm3357"/>
-			<unit id="org.eclipse.jsf.feature.source.feature.group" version="3.4.0.v201111022140-7E7JFBZF9JgLWZLz0U0QoZm3357"/>			
 			<unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.4.0.v201108231500-377DG8s73543J5H6D66"/>
 			<unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.4.0.v201108110300-52FShAkF7BA8O8J9OC8"/>
 			<unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.4.0.v201107072300-7b7JIM0FSK2WM1PS9Ar7AKUz0TrWn"/>
@@ -379,7 +369,6 @@
 		</location>
 
 		<!-- Only in JBT: SWTBot -->
-		<!--
 		<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/swtbot/2.0.5/"/>
 			<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.0.5.20111003_1754-3676ac8-dev-e36"/>
@@ -388,28 +377,22 @@
 			<unit id="org.eclipse.swtbot.eclipse.test.junit4.feature.group" version="2.0.5.20111003_1754-3676ac8-dev-e36"/>
 			<unit id="org.eclipse.swtbot.feature.group" version="2.0.5.20111003_1754-3676ac8-dev-e36"/>
 		</location>
-		-->
 
 		<!-- Only in JBT: BIRT -->
-		<!--
 		<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/birt/4.2.0.v20120613/"/>
-			<unit id="org.eclipse.birt.osgi.runtime.sdk.feature.group" version="4.2.0.v20120611-793-87iDWCFP8ZDTAN72TPI4jrXA"/>
 			<unit id="org.eclipse.birt.feature.group" version="4.2.0.v20120611-C_BC7CGWoJMfAnw8Y8QVz0nD0JPl"/>
 			<unit id="org.eclipse.birt.integration.wtp.feature.group" version="4.2.0.v20120613-1143-51-7w3123172402254"/>
 			<unit id="org.eclipse.birt.chart.feature.group" version="4.2.0.v20120611-828i2FQCnvK_6W8GmbB8"/>
 			<unit id="org.eclipse.birt.chart.integration.wtp.feature.group" version="4.2.0.v20120613-1143-51-7w3123172402254"/>
 		</location>
-		-->
 
 		<!-- Only in JBT: GWT/GPE -->
-		<!-- 
 		<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/gwt/3.1.0.v201208080121-rel-r42"/>
 			<unit id="com.google.gdt.eclipse.suite.e42.feature.feature.group" version="3.1.0.v201208080121-rel-r42"/>
 			<unit id="com.google.gwt.eclipse.sdkbundle.e42.feature.feature.group" version="2.4.0.v201208080121-rel-r42"/>
 		</location>
-		-->
 
 	</locations>
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>

--- a/target-platforms/jbosstools-4.2.0.d/multiple/pom.xml
+++ b/target-platforms/jbosstools-4.2.0.d/multiple/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.1.a-SNAPSHOT</version>
+		<version>4.2.0.d-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
 	<artifactId>multiple</artifactId>
-	<name>jbosstools Multiple (Composite) Target Platform 4.2.1.a</name>
+	<name>jbosstools Multiple (Composite) Target Platform 4.2.0.d</name>
 	<packaging>pom</packaging>
 
 	<build>
@@ -59,7 +59,7 @@
 			</plugin>
 		</plugins>
 	</build>
-
+	
 	<profiles>
 		<profile>
 			<id>multiple2repo</id>

--- a/target-platforms/jbosstools-4.2.0.d/pom.xml
+++ b/target-platforms/jbosstools-4.2.0.d/pom.xml
@@ -7,9 +7,9 @@
 		<artifactId>target-platforms</artifactId>
 		<version>4.1.0.Alpha1-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
+	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
 	<artifactId>all</artifactId>
-	<version>4.2.0.c-SNAPSHOT</version>
+	<version>4.2.0.d-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>multiple</module>

--- a/target-platforms/jbosstools-4.2.0.d/unified/pom.xml
+++ b/target-platforms/jbosstools-4.2.0.d/unified/pom.xml
@@ -3,17 +3,39 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
+		<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.0.c-SNAPSHOT</version>
+		<version>4.2.0.d-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
-	<artifactId>multiple</artifactId>
-	<name>jbdevstudio Multiple (Composite) Target Platform 4.2.0.c</name>
+	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
+	<artifactId>unified</artifactId>
+	<name>jbosstools Unified (Aggregate) Target Platform 4.2.0.d</name>
 	<packaging>pom</packaging>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.jboss.tools.tycho-plugins</groupId>
+				<artifactId>target-platform-utils</artifactId>
+				<version>0.0.1-SNAPSHOT</version>
+				<executions>
+					<execution>
+						<id>create-target</id>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>flatten-target</goal>
+						</goals>
+						<configuration>
+							<sourceTargetArtifact>
+								<groupId>${project.groupId}</groupId>
+								<artifactId>multiple</artifactId>
+								<version>${project.version}</version>
+							</sourceTargetArtifact>
+							<targetRepositoryUrl>http://download.jboss.org/jbosstools/updates/juno/SR0c/REPO/</targetRepositoryUrl>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>target-platform-validation-plugin</artifactId>
@@ -26,7 +48,7 @@
 						</goals>
 						<configuration>
 							<targetFiles>
-								<param>multiple.target</param>
+								<param>${project.build.directory}/${project.artifactId}.target</param>
 							</targetFiles>
 							<failOnError>true</failOnError>
 						</configuration>
@@ -46,11 +68,10 @@
 						</goals>
 						<configuration>
 							<artifacts>
-								<!-- add more artifacts if want more target platforms -->
 								<artifact>
-									<file>multiple.target</file>
+									<file>${project.build.directory}/${project.artifactId}.target</file>
 									<type>target</type>
-									<classifier>multiple</classifier>
+									<classifier>${project.artifactId}</classifier>
 								</artifact>
 							</artifacts>
 						</configuration>
@@ -59,32 +80,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<profiles>
-		<profile>
-			<id>multiple2repo</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=389052  -->
-						<groupId>org.jboss.tools.tycho-plugins</groupId>
-						<artifactId>target-platform-utils</artifactId>
-						<version>0.0.1-SNAPSHOT</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>mirror-target-to-repo</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-	
 </project>

--- a/target-platforms/jbosstools-4.2.1.b/multiple/multiple.target
+++ b/target-platforms/jbosstools-4.2.1.b/multiple/multiple.target
@@ -75,8 +75,9 @@
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/m2eclipse/20120926-1337/"/>
 
 			<!-- m2e, m2e-wtp, m2e-apt, m2e-jdt, m2e-wro4j, m2e-buildhelper + deps -->
-			<unit id="org.eclipse.m2e.sdk.feature.feature.group" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.feature.feature.group" version="1.2.0.20120903-1050"/>
+			<!-- Maven tests require a bundle from m2e SDK -->
+			<unit id="org.eclipse.m2e.tests.common" version="1.2.0.20120903-1050"/>
 			<unit id="org.eclipse.m2e.wtp.feature.feature.group" version="0.16.0.20120914-0945"/>
 			<unit id="org.sonatype.m2e.mavenarchiver.feature.feature.group" version="0.15.0.201207090125-signed-201209140800"/>
 			<unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.0.1.201209200721"/>
@@ -136,21 +137,12 @@
 			<!-- <unit id="org.eclipse.platform.feature.group" version="3.8.0.v20120607-071945-9gF7jI7nG5qByXMVdkhRMWBQlF4PnDCLybDCPQ"/> -->
 			<unit id="org.eclipse.platform.feature.group" version="4.2.1.v20120814-120134-9JF7BHVGFyMveli1uX6aTH0q-eAap6PAgOP5mO"/>
 			<unit id="org.eclipse.platform.ide" version="4.2.1.M20120914-1800"/>
-			<unit id="org.eclipse.platform.sdk" version="4.2.1.M20120914-1800"/>
-			<unit id="org.eclipse.sdk.feature.group" version="4.2.1.v20120814-120134-7T7oDODQ-3Heq-afCDlg7T4xJuvxaC2ohMfCfB5451Rz0"/>
-			<unit id="org.eclipse.sdk.ide" version="4.2.1.M20120914-1800"/>
 			<unit id="org.eclipse.cvs.feature.group" version="1.3.200.v20120525-1249-7B79FJJAkF7BF7VEH5IAJT"/>
 			<unit id="org.eclipse.jdt.feature.group" version="3.8.1.v20120814-104540-8-8nFqpFNOfwKDRVz-tXOcL5d_83"/>
 			<unit id="org.eclipse.equinox.server.core.feature.group" version="1.2.0.v20120522-1841-7K7VFO1F7RZHQZI4_c8StnvFB"/>
 			<unit id="org.eclipse.equinox.executable.feature.group" version="3.6.0.v20120522-1813-7P7OG2BFLWUl7UmbVUO9iCm"/>
-			<unit id="org.eclipse.equinox.compendium.sdk.feature.group" version="3.8.0.v20120522-1841-7X7eGb7FPGjtJjv1kjS_NdG"/>
-			<unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.8.0.v20120522-1813-85FAcGbFFoYTldJrUNk3a52oHJ"/>
 			<unit id="org.eclipse.equinox.p2.discovery.feature.feature.group" version="1.0.100.v20120524-0542-4-Bh9oB58A5N9L28PCQ"/>
 			<unit id="org.eclipse.equinox.p2.user.ui.feature.group" version="2.2.0.v20120524-0542-62DG9JXTlSiz-UbcP0w0KGl9CKNP"/>
-			<unit id="org.eclipse.equinox.p2.sdk.feature.group" version="3.8.0.v20120524-0542-9N89H_oGMMn84Qsz0iIohu4jLeQD"/>
-			<unit id="org.eclipse.equinox.serverside.sdk.feature.group" version="3.8.0.v20120522-1841-9Q7dFszFYGis9uZsz0QodZP4fL9p"/>
-			<unit id="org.eclipse.equinox.sdk.feature.group" version="3.8.0.v20120522-1841-7M7fA78g5_y-g-jtHxcd5k8q8lFR"/>
-			<unit id="org.eclipse.equinox.weaving.sdk.feature.group" version="1.0.200.v20120522-1841-79-FKsEVVFNVFsVk7O6G6"/>
 			<unit id="org.eclipse.equinox.server.jetty.feature.group" version="1.1.0.v20120522-1841-8077C0F8NcJTbL1ab47MJ5"/>
 			<unit id="org.eclipse.equinox.server.p2.feature.group" version="1.2.0.v20120522-1841-7z7_FfoFTy21Yu4Ykq_engx38"/>
 			<unit id="org.eclipse.equinox.server.servletbridge.feature.group" version="1.0.101.v20120522-1841-42F9w9oB58B5KBB2ADHO"/>
@@ -249,7 +241,6 @@
 			<unit id="org.eclipse.mylyn.cvs.feature.group" version="1.0.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.git.feature.group" version="1.0.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.versions.feature.group" version="1.0.2.v20120916-1200"/>
-			<unit id="org.eclipse.mylyn.commons.sdk.feature.group" version="3.8.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.tasks.ui" version="3.8.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.tasks.core" version="3.8.2.v20120916-1200"/>
 			<unit id="org.eclipse.mylyn.tasks.bugs" version="3.8.2.v20120916-1200"/>
@@ -333,7 +324,6 @@
 			<unit id="org.eclipse.jpt.jaxb.feature.feature.group" version="1.2.1.v201208222210-56ABAkF7BF7cFFFFB7"/>
 
 			<unit id="org.eclipse.jsf.feature.feature.group" version="3.4.1.v201208241503-7E7JFBjF9JgLWgMhh4X6Ps"/>
-			<unit id="org.eclipse.jsf.feature.source.feature.group" version="3.4.1.v201208241503-7E7JFBjF9JgLWgMhh4X6Ps"/>
 			<unit id="org.eclipse.jst.common.fproj.enablement.jdt.feature.group" version="3.4.0.v201108231500-377DG8s73543J5H6D66"/>
 			<unit id="org.eclipse.jst.enterprise_core.feature.feature.group" version="3.4.0.v201108110300-52FShAkF7BA8O8J9OC8"/>
 			<unit id="org.eclipse.jst.enterprise_ui.feature.feature.group" version="3.4.0.v201107072300-7b7JIM0FSK2WM1PS9Ar7AKUz0TrWn"/>
@@ -391,7 +381,6 @@
 		<!-- Only in JBT: BIRT -->
 		<location includeAllPlatforms="false" includeMode="planner" type="InstallableUnit" includeSource="true">
 			<repository location="http://download.jboss.org/jbosstools/updates/requirements/birt/4.2.1.v20120912/"/>
-			<unit id="org.eclipse.birt.osgi.runtime.sdk.feature.group" version="4.2.1.v20120820-793187qD_D0RBQLXOVH-wQkmJ1cI"/>
 			<unit id="org.eclipse.birt.feature.group" version="4.2.1.v20120820-ChBG8UGYgRQlJ7y9Lz-wS7nDcRL4"/>
 			<unit id="org.eclipse.birt.integration.wtp.feature.group" version="4.2.1.v20120912-1721-5107w31231A2302832"/>
 			<unit id="org.eclipse.birt.chart.feature.group" version="4.2.1.v20120820-828i7EFQCnvK_6wFGvqLR"/>

--- a/target-platforms/jbosstools-4.2.1.b/multiple/pom.xml
+++ b/target-platforms/jbosstools-4.2.1.b/multiple/pom.xml
@@ -5,37 +5,15 @@
 	<parent>
 		<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.0.c-SNAPSHOT</version>
+		<version>4.2.1.b-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
-	<artifactId>unified</artifactId>
-	<name>jbosstools Unified (Aggregate) Target Platform 4.2.0.c</name>
+	<artifactId>multiple</artifactId>
+	<name>jbosstools Multiple (Composite) Target Platform 4.2.1.b</name>
 	<packaging>pom</packaging>
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.jboss.tools.tycho-plugins</groupId>
-				<artifactId>target-platform-utils</artifactId>
-				<version>0.0.1-SNAPSHOT</version>
-				<executions>
-					<execution>
-						<id>create-target</id>
-						<phase>generate-resources</phase>
-						<goals>
-							<goal>flatten-target</goal>
-						</goals>
-						<configuration>
-							<sourceTargetArtifact>
-								<groupId>${project.groupId}</groupId>
-								<artifactId>multiple</artifactId>
-								<version>${project.version}</version>
-							</sourceTargetArtifact>
-							<targetRepositoryUrl>http://download.jboss.org/jbosstools/updates/juno/SR0c/REPO/</targetRepositoryUrl>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>target-platform-validation-plugin</artifactId>
@@ -48,7 +26,7 @@
 						</goals>
 						<configuration>
 							<targetFiles>
-								<param>${project.build.directory}/${project.artifactId}.target</param>
+								<param>multiple.target</param>
 							</targetFiles>
 							<failOnError>true</failOnError>
 						</configuration>
@@ -68,8 +46,9 @@
 						</goals>
 						<configuration>
 							<artifacts>
+								<!-- add more artifacts if want more target platforms -->
 								<artifact>
-									<file>${project.build.directory}/${project.artifactId}.target</file>
+									<file>multiple.target</file>
 									<type>target</type>
 									<classifier>${project.artifactId}</classifier>
 								</artifact>
@@ -80,4 +59,32 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>multiple2repo</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<!-- Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=389052  -->
+						<groupId>org.jboss.tools.tycho-plugins</groupId>
+						<artifactId>target-platform-utils</artifactId>
+						<version>0.0.1-SNAPSHOT</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>mirror-target-to-repo</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/target-platforms/jbosstools-4.2.1.b/pom.xml
+++ b/target-platforms/jbosstools-4.2.1.b/pom.xml
@@ -7,9 +7,9 @@
 		<artifactId>target-platforms</artifactId>
 		<version>4.1.0.Alpha1-SNAPSHOT</version>
 	</parent>
-	<groupId>org.jboss.tools.target-platforms.jbdevstudio</groupId>
+	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
 	<artifactId>all</artifactId>
-	<version>4.2.1.a-SNAPSHOT</version>
+	<version>4.2.1.b-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>multiple</module>

--- a/target-platforms/jbosstools-4.2.1.b/unified/pom.xml
+++ b/target-platforms/jbosstools-4.2.1.b/unified/pom.xml
@@ -5,15 +5,37 @@
 	<parent>
 		<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
 		<artifactId>all</artifactId>
-		<version>4.2.0.c-SNAPSHOT</version>
+		<version>4.2.1.b-SNAPSHOT</version>
 	</parent>
 	<groupId>org.jboss.tools.target-platforms.jbosstools</groupId>
-	<artifactId>multiple</artifactId>
-	<name>jbosstools Multiple (Composite) Target Platform 4.2.0.c</name>
+	<artifactId>unified</artifactId>
+	<name>jbosstools Unified (Aggregate) Target Platform 4.2.1.b</name>
 	<packaging>pom</packaging>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.jboss.tools.tycho-plugins</groupId>
+				<artifactId>target-platform-utils</artifactId>
+				<version>0.0.1-SNAPSHOT</version>
+				<executions>
+					<execution>
+						<id>create-target</id>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>flatten-target</goal>
+						</goals>
+						<configuration>
+							<sourceTargetArtifact>
+								<groupId>${project.groupId}</groupId>
+								<artifactId>multiple</artifactId>
+								<version>${project.version}</version>
+							</sourceTargetArtifact>
+							<targetRepositoryUrl>http://download.jboss.org/jbosstools/updates/juno/SR1a/REPO/</targetRepositoryUrl>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>target-platform-validation-plugin</artifactId>
@@ -26,7 +48,7 @@
 						</goals>
 						<configuration>
 							<targetFiles>
-								<param>multiple.target</param>
+								<param>${project.build.directory}/${project.artifactId}.target</param>
 							</targetFiles>
 							<failOnError>true</failOnError>
 						</configuration>
@@ -46,9 +68,8 @@
 						</goals>
 						<configuration>
 							<artifacts>
-								<!-- add more artifacts if want more target platforms -->
 								<artifact>
-									<file>multiple.target</file>
+									<file>${project.build.directory}/${project.artifactId}.target</file>
 									<type>target</type>
 									<classifier>${project.artifactId}</classifier>
 								</artifact>
@@ -59,32 +80,4 @@
 			</plugin>
 		</plugins>
 	</build>
-	
-	<profiles>
-		<profile>
-			<id>multiple2repo</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<!-- Workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=389052  -->
-						<groupId>org.jboss.tools.tycho-plugins</groupId>
-						<artifactId>target-platform-utils</artifactId>
-						<version>0.0.1-SNAPSHOT</version>
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>mirror-target-to-repo</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 </project>

--- a/target-platforms/pom.xml
+++ b/target-platforms/pom.xml
@@ -33,29 +33,29 @@
 		<profile>
 			<id>jbdevstudio-maximum</id>
 			<modules>
-				<module>jbdevstudio-4.2.1.a/multiple</module>
-				<module>jbdevstudio-4.2.1.a/unified</module>
+				<module>jbdevstudio-4.2.1.b/multiple</module>
+				<module>jbdevstudio-4.2.1.b/unified</module>
 			</modules>
 		</profile>
 		<profile>
 			<id>jbosstools-maximum</id>
 			<modules>
-				<module>jbosstools-4.2.1.a/multiple</module>
-				<module>jbosstools-4.2.1.a/unified</module>
+				<module>jbosstools-4.2.1.b/multiple</module>
+				<module>jbosstools-4.2.1.b/unified</module>
 			</modules>
 		</profile>
 		<profile>
 			<id>jbdevstudio-minimum</id>
 			<modules>
-				<module>jbdevstudio-4.2.0.c/multiple</module>
-				<module>jbdevstudio-4.2.0.c/unified</module>
+				<module>jbdevstudio-4.2.0.d/multiple</module>
+				<module>jbdevstudio-4.2.0.d/unified</module>
 			</modules>
 		</profile>
 		<profile>
 			<id>jbosstools-minimum</id>
 			<modules>
-				<module>jbosstools-4.2.0.c/multiple</module>
-				<module>jbosstools-4.2.0.c/unified</module>
+				<module>jbosstools-4.2.0.d/multiple</module>
+				<module>jbosstools-4.2.0.d/unified</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/target-platforms/publish.sh
+++ b/target-platforms/publish.sh
@@ -23,42 +23,42 @@ while [ "$#" -gt 0 ]; do
 		'-include') include="$2"; shift 2;;
 		'-exclude') exclude="$2"; shift 2;;
 
-		'-jbosstools-4.2.1.a')
+		'-jbosstools-4.2.1.b')
 			# defaults for JBT (trunk)
 			targetZipFile=e421-wtp341.target
-			repoDir=/home/hudson/static_build_env/jbds/tools/sources/REPO_4.0.juno.SR1a
-			destinationPath=/home/hudson/static_build_env/jbds/target-platform_4.0.juno.SR1a
-			DESTINATION=tools@filemgmt.jboss.org:/downloads_htdocs/tools/updates/juno/SR1a
+			repoDir=/home/hudson/static_build_env/jbds/tools/sources/REPO_4.0.juno.SR1b
+			destinationPath=/home/hudson/static_build_env/jbds/target-platform_4.0.juno.SR1b
+			DESTINATION=tools@filemgmt.jboss.org:/downloads_htdocs/tools/updates/juno/SR1b
 			include="*"
 			exclude="--exclude '.blobstore'" # exclude the .blobstore
 			shift 1;;
 
-		'-jbdevstudio-4.2.1.a')
+		'-jbdevstudio-4.2.1.b')
 			# defaults for JBDS (trunk)
 			targetZipFile=jbds600-e421-wtp341.target
-			repoDir=/home/hudson/static_build_env/jbds/tools/sources/JBDS-REPO_4.0.juno.SR1a
-			destinationPath=/home/hudson/static_build_env/jbds/jbds-target-platform_4.0.juno.SR1a
-			DESTINATION=/qa/services/http/binaries/RHDS/updates/jbds-target-platform_4.0.juno.SR1a
+			repoDir=/home/hudson/static_build_env/jbds/tools/sources/JBDS-REPO_4.0.juno.SR1b
+			destinationPath=/home/hudson/static_build_env/jbds/jbds-target-platform_4.0.juno.SR1b
+			DESTINATION=/qa/services/http/binaries/RHDS/updates/jbds-target-platform_4.0.juno.SR1b
 			include="*"
 			exclude="--exclude '.blobstore'" # exclude the .blobstore
 			shift 1;;
 
-		'-jbosstools-4.2.0.c')
+		'-jbosstools-4.2.0.d')
 			# defaults for JBT (trunk)
 			targetZipFile=e420-wtp340.target
-			repoDir=/home/hudson/static_build_env/jbds/tools/sources/REPO_4.0.juno.SR0c
-			destinationPath=/home/hudson/static_build_env/jbds/target-platform_4.0.juno.SR0c
-			DESTINATION=tools@filemgmt.jboss.org:/downloads_htdocs/tools/updates/juno/SR0c
+			repoDir=/home/hudson/static_build_env/jbds/tools/sources/REPO_4.0.juno.SR0d
+			destinationPath=/home/hudson/static_build_env/jbds/target-platform_4.0.juno.SR0d
+			DESTINATION=tools@filemgmt.jboss.org:/downloads_htdocs/tools/updates/juno/SR0d
 			include="*"
 			exclude="--exclude '.blobstore'" # exclude the .blobstore
 			shift 1;;
 
-		'-jbdevstudio-4.2.0.c')
+		'-jbdevstudio-4.2.0.d')
 			# defaults for JBDS (trunk)
 			targetZipFile=jbds600-e420-wtp340.target
-			repoDir=/home/hudson/static_build_env/jbds/tools/sources/JBDS-REPO_4.0.juno.SR0c
-			destinationPath=/home/hudson/static_build_env/jbds/jbds-target-platform_4.0.juno.SR0c
-			DESTINATION=/qa/services/http/binaries/RHDS/updates/jbds-target-platform_4.0.juno.SR0c
+			repoDir=/home/hudson/static_build_env/jbds/tools/sources/JBDS-REPO_4.0.juno.SR0d
+			destinationPath=/home/hudson/static_build_env/jbds/jbds-target-platform_4.0.juno.SR0d
+			DESTINATION=/qa/services/http/binaries/RHDS/updates/jbds-target-platform_4.0.juno.SR0d
 			include="*"
 			exclude="--exclude '.blobstore'" # exclude the .blobstore
 			shift 1;;
@@ -79,7 +79,7 @@ if [[ -d ${repoDir} ]]; then
 
 	# JBDS-2380 massage content.jar to remove all external 3rd party references: target platform site should be self contained
 	wget --no-check-certificate https://raw.github.com/jbosstools/jbosstools-download.jboss.org/master/jbosstools/updates/requirements/remove.references.xml
-	ant -f remove.references.xml -DworkDir=`pwd` 
+	ant -f remove.references.xml -DworkDir=`pwd`
 	rm -f remove.references.xml
 
 	# copy/update into central place for reuse by local downstream build jobs


### PR DESCRIPTION
- increased TP versions to .b and .d
- kept org.eclipse.m2e.tests.common
- kept GDT sdkbundle (required by GWT tools)
