### PR TITLE
JBIDE-16161 - Tycho tests require org.eclipse.osgi.compatibility.state fragment on Luna

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -225,6 +225,13 @@
 						<include>**/*AllBotTests*.class</include>
 						<include>**/*TestSuite*.class</include>
 					</includes>
+					<dependencies>
+					    <dependency>
+							<type>eclipse-feature</type>
+							<artifactId>org.eclipse.e4.rcp</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+					</dependencies>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-16161
Tycho tests require org.eclipse.osgi.compatibility.state fragment on Luna
