### PR TITLE
JBIDE-17255 Upgrade jacoco version to support JDK 1.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -280,7 +280,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.6.4.201312101107</version>
+				<version>0.7.1.201405082137</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
The current version that we use fails to run with java 8. The new version
fixes that.
