### PR TITLE
JBIDE-15332: Unlink skipTests and skip requirements

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -40,8 +40,10 @@
 		<!-- SWITCHES can be overriden by command-line -Dkey=value -->
 		<!-- ===================================================== -->
 		<swtbot.test.skip>true</swtbot.test.skip>
-		<!-- Used to install 3rd-party runtimes for testing -->
-		<skipRequirements>${skipTests}</skipRequirements>
+		<!-- Used to install 3rd-party runtimes, cascaded to download-maven-plugin and maven-dependency-plugin -->
+		<skipRequirements>false</skipRequirements>
+		<!-- Used to install 3rd-party runtimes for testing, cascaded to download-maven-plugin and maven-dependency-plugin -->
+		<skipTestRequirements>${skipTests}</skipTestRequirements>
 		<!-- Skip downloading private stuff, to be propagated to tests to skip executing test based on private stuff -->
 		<!-- See JBIDE-12420 -->
 		<skipPrivateRequirements>true</skipPrivateRequirements>
@@ -651,6 +653,7 @@
 			</activation>
 			<properties>
 				<maven.test.skip>true</maven.test.skip>
+				<skipTestRequirements>true</skipTestRequirements>
 				<skipTestsWithPrivateRequirements>true</skipTestsWithPrivateRequirements>
 			</properties>
 		</profile>


### PR DESCRIPTION
Several "functional" bundles have requirements that we'll
almost always want to fetch (forge runtime, ripple, ...),
independently of whether tests are enabled or not.
We introduce a skipTestRequirements property that test plugins
fetching content should set to true in their pom (or in their
immediate parent tests/pom.xml)