### PR TITLE
use consistent case/naming of jbossTychoVersion

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -21,7 +21,7 @@
 		<!-- to build w/ latest 0.15.0-SNAPSHOT, run `mvn install -DtychoVersion=0.15.0-SNAPSHOT` -->
 		<tychoVersion>0.22.0</tychoVersion>
 		<tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
-		<JBossTychoPluginsVersion>0.22.0</JBossTychoPluginsVersion>
+		<jbossTychoVersion>${tychoVersion}</jbossTychoVersion>
 		<memoryOptions1>-Xms512m -Xmx1024m -XX:PermSize=256m</memoryOptions1>
 		<memoryOptions2>-XX:MaxPermSize=256m</memoryOptions2>
 		<systemProperties></systemProperties>
@@ -310,7 +310,7 @@
 			<plugin>
 				<groupId>org.jboss.tools.tycho-plugins</groupId>
 				<artifactId>repository-utils</artifactId>
-				<version>${JBossTychoPluginsVersion}</version>
+				<version>${jbossTychoVersion}</version>
 				<executions>
 					<execution>
 						<id>generate-facade</id>


### PR DESCRIPTION
Ours and mvn properties does not start with uppercase and does not generally include "Plugin" in their name.

Also made it so tychoVersion is used as default for jbossTychoVersion since I cannot imagine a case where these
would be different in practice ?

Have that ever happened ? Do they not need to be compiled against eachother everytime anyway ?

...and if they are compatible by chance we can override/change it.