### PR TITLE
Fix maven error markers for maven-dependency-plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -382,6 +382,29 @@
 										<ignore></ignore>
 									</action>
 								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.apache.maven.plugins
+										</groupId>
+										<artifactId>
+											maven-dependency-plugin
+										</artifactId>
+										<versionRange>
+											[2.4,)
+										</versionRange>
+										<goals>
+											<goal>copy</goal>
+											<goal>copy-dependencies</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+									<execute>
+									<runOnConfiguration>true</runOnConfiguration>
+									<runOnIncremental>false</runOnIncremental>
+									</execute>
+									</action>
+								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
 					</configuration>


### PR DESCRIPTION
Fix contains configuration to fix markers on pom.xml's
usin maven-dependency-plugin to download dependencies
like: "Plugin execution not covered by lifecycle
configuration:
org.apache.maven.plugins:maven-dependency-plugin:2.4:copy
(execution: get-libs, phase: generate-resources)"
