### PR TITLE
Correction of a comment wrt maven.test.skip and skipTests function

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -230,7 +230,8 @@
 				</configuration>
 			</plugin>
 
-			<!-- to skip running tests (compile only) use commandline flag: -Dmaven.test.skip
+			<!-- to skip running (and compiling) tests use commandline flag: -Dmaven.test.skip
+				To skip tests, but still compile them, use: -DskipTests
 				To allow all tests in a pom to pass/fail, use commandline flag: -fae (fail
 				at end) -->
 			<plugin>


### PR DESCRIPTION
A comment in the parent pom wrongly said that maven.test.skip will
still compile the tests, but not run them.
See http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-test.html