### PR TITLE
JBIDE-13671 strict use of jgit timestamps...

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -152,7 +152,11 @@
 				<artifactId>tycho-packaging-plugin</artifactId>
 				<version>${tychoVersion}</version>
 				<configuration>
-					<format>'${BUILD_ALIAS}-v'yyyyMMdd-HHmm</format>
+					<format>'${BUILD_ALIAS}-v'yyyyMMdd-HHmm'-LOCAL'</format>
+					<strictBinIncludes>false</strictBinIncludes>
+					<timestampProvider>jgit</timestampProvider>
+					<jgit.dirtyWorkingTree>warning</jgit.dirtyWorkingTree>
+					<jgit.ignore></jgit.ignore>
 					<sourceReferences>
 						<generate>true</generate>
 					</sourceReferences>
@@ -189,6 +193,11 @@
 					<dependency>
 						<groupId>org.eclipse.tycho.extras</groupId>
 						<artifactId>tycho-sourceref-jgit</artifactId>
+						<version>${tychoExtrasVersion}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.tycho.extras</groupId>
+						<artifactId>tycho-buildtimestamp-jgit</artifactId>
 						<version>${tychoExtrasVersion}</version>
 					</dependency>
 				</dependencies>
@@ -692,8 +701,8 @@
 						<artifactId>tycho-packaging-plugin</artifactId>
 						<version>${tychoVersion}</version>
 						<configuration>
-							<format>'${BUILD_ALIAS}-v'yyyyMMdd-HHmm'-B${BUILD_NUMBER}'</format>
-							<archiveSite>true</archiveSite>
+							<jgit.dirtyWorkingTree>error</jgit.dirtyWorkingTree>
+							<format>'${BUILD_ALIAS}-v'yyyyMMdd-HHmm'-ci'</format>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
JBIDE-13671 strict use of jgit timestamps and 'ci' suffix for Jenkins builds; warning and fallback to default timestamp provider for local builds with 'LOCAL' suffix