### PR TITLE
JBIDE-23657 switch from PermSize to...

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -30,8 +30,8 @@
 		<tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
 		<jbossTychoPluginsVersion>0.26.1-SNAPSHOT</jbossTychoPluginsVersion>
 		<jbosstoolsRelengPublishVersion>4.4.1.AM2-SNAPSHOT</jbosstoolsRelengPublishVersion>
-		<memoryOptions1>-Xms512m -Xmx1024m -XX:PermSize=256m</memoryOptions1>
-		<memoryOptions2>-XX:MaxPermSize=256m</memoryOptions2>
+		<memoryOptions1>-Xms512m -Xmx1024m -XX:MetaspaceSize=256m</memoryOptions1>
+		<memoryOptions2></memoryOptions2>
 		<systemProperties></systemProperties>
 		<platformSystemProperties></platformSystemProperties>
 		<applejdkProperties></applejdkProperties>


### PR DESCRIPTION
JBIDE-23657 switch from PermSize to MetaspaceSize (since we requite JDK8); also bump MaxMetaspaceSize to 512m from 256m

Signed-off-by: nickboldt <nboldt@redhat.com>