### PR TITLE
JBIDE-16161 revert addition of dependency on...

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -299,13 +299,7 @@ hs_err_pid*.log</jgit.ignore>
 						<include>**/*AllBotTests*.class</include>
 						<include>**/*TestSuite*.class</include>
 					</includes>
-					<!-- Workaround for JBIDE-16161/Eclipse bug 424104 -->
 					<dependencies>
-						<dependency>
-							<type>eclipse-feature</type>
-							<artifactId>org.eclipse.e4.rcp</artifactId>
-							<version>0.0.0</version>
-						</dependency>
 						<!-- This feature is required for correct Installed JRE initialization on Mac OS X -->
 						<dependency>
 							<type>eclipse-feature</type>


### PR DESCRIPTION
JBIDE-16161 revert addition of dependency on org.eclipse.e4.rcp feature, now that fixed upstream

Signed-off-by: nickboldt <nboldt@redhat.com>