### PR TITLE
JBIDE-25220 update parent pom to mention...

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -15,7 +15,7 @@
 		<!-- Build properties, to be updated with every milestone or new Eclipse release -->
 		<!-- ==================================================== -->
 		<BUILD_ALIAS>Final</BUILD_ALIAS>
-		<targetEclipseVersion>4.7.1 (Oxygen)</targetEclipseVersion>
+		<targetEclipseVersion>4.7.1a (Oxygen)</targetEclipseVersion>
 		<eclipseReleaseName>oxygen</eclipseReleaseName>
 		<devstudioReleaseVersion>11</devstudioReleaseVersion>
 		<!-- Integration Test (ITest) parameters -->


### PR DESCRIPTION
JBIDE-25220 update parent pom to mention targetEclipseVersion = 4.7.1a (Oxygen), instead of 4.7.1

Signed-off-by: nickboldt <nboldt@redhat.com>