### PR TITLE
JBIDE-26336 - upgrade jacoco from 0.8.1 to 0.8.2 for Java 11 profile

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -899,7 +899,7 @@ hs_err_pid*.log</jgit.ignore>
 				<jdeps-jdk-version>11</jdeps-jdk-version>
 				<jdeps-jdk-vendor>openjdk</jdeps-jdk-vendor>
 				<moduleProperties>--add-modules=ALL-SYSTEM</moduleProperties>
-				<jacoco.version>0.8.1</jacoco.version>
+				<jacoco.version>0.8.2</jacoco.version>
 			</properties>
 		</profile>
 


### PR DESCRIPTION
Signed-off-by: Aurélien Pupier <apupier@redhat.com>