### PR TITLE
JBIDE-26457 Remove x86 platforms from parent POM

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -212,17 +212,7 @@ hs_err_pid*.log</jgit.ignore>
 						<environment>
 							<os>win32</os>
 							<ws>win32</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
 							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
-							<arch>x86</arch>
 						</environment>
 						<environment>
 							<os>linux</os>
@@ -268,17 +258,7 @@ hs_err_pid*.log</jgit.ignore>
 						<environment>
 							<os>win32</os>
 							<ws>win32</ws>
-							<arch>x86</arch>
-						</environment>
-						<environment>
-							<os>win32</os>
-							<ws>win32</ws>
 							<arch>x86_64</arch>
-						</environment>
-						<environment>
-							<os>linux</os>
-							<ws>gtk</ws>
-							<arch>x86</arch>
 						</environment>
 						<environment>
 							<os>linux</os>


### PR DESCRIPTION
Signed-off-by: Josef Kopriva <jkopriva@redhat.com>