### PR TITLE
JBDS-4730: Use "Red Hat CodeReady Studio" instead of "Red Hat Develop…

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -6,8 +6,8 @@
 	<artifactId>parent</artifactId>
 		<version>4.11.0.AM1-SNAPSHOT</version>
 	<packaging>pom</packaging>
-	<name>JBoss Tools and Red Hat Developer Studio Parent</name>
-	<description>JBoss Tools and Red Hat Developer Studio Parent</description>
+	<name>JBoss Tools and Red Hat CodeReady Studio Parent</name>
+	<description>JBoss Tools and Red Hat CodeReady Studio Parent</description>
 	<url>https://developers.redhat.com/products/devstudio/overview/</url>
 
 	<properties>


### PR DESCRIPTION
…er Studio" in graphics & text

Signed-off-by: Jeff MAURY <jmaury@redhat.com>