### PR TITLE
JBIDE-28423: migrate rsync scripts.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -33,8 +33,8 @@
 
 		<!-- if https://issues.jboss.org/browse/JBIDE-22248 comes back, use <jbossNexus>origin-repository.jboss.org</jbossNexus> -->
 		<jbossNexus>repository.jboss.org</jbossNexus>
-		<!-- https://issues.jboss.org/browse/JBIDE-23965 performance tuning for filemgmt.jboss.org - use IP as it's 3x faster (but subject to change) -->
-		<filemgmtJbossOrg>10.5.105.197</filemgmtJbossOrg>
+		
+		<filemgmtJbossOrg>filemgmt-prod-sync.jboss.org</filemgmtJbossOrg>
 
 		<!-- ==================================================== -->
 		<!-- General properties, not meant to be tweaked by users -->


### PR DESCRIPTION
first iteration is to use the new rsyncserver before moving to sftp.
Signed-off-by: Stephane Bouchet <sbouchet@redhat.com>